### PR TITLE
chore: removed link to test linter

### DIFF
--- a/.github/markdownlint-rules
+++ b/.github/markdownlint-rules
@@ -4,8 +4,7 @@
   "MD033": false,
   "MD025": false,
   "MD051": false,
-  "MD045": false
-  "MD036": false
+  "MD045": false,
+  "MD036": false,
   "MD029": false
-
 }

--- a/.github/workflows/md-lint.yml
+++ b/.github/workflows/md-lint.yml
@@ -3,9 +3,6 @@ name: Markdown lint
 on:
   pull_request:
     branches: [main]
-  push:
-    branches-ignore:
-      - markdown-lint
 
 jobs: 
   lint:

--- a/.github/workflows/md-lint.yml
+++ b/.github/workflows/md-lint.yml
@@ -11,6 +11,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+
       - name: markdownlint-cli
         uses: nosborn/github-action-markdown-cli@v3.3.0
         with:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Afin d'aboutir à une définition du bâtiment satisfaisante, il est nécessaire
 Diverses initiatives ont été menées par l'équipe Bat-ID :
 
 * des ateliers de co-création de définitions auprès de plusieurs organisations productrices de données, dont les résultats sont disponibles [ici](docs/Synthèse-Ateliers-de-Définition-Bat-ID.pdf).
-* une concertation élargie auprès de nombreux acteurs, entre autre via les forums des [géocommuns]() et de [team open data](https://teamopendata.org/t/identifiant-unique-batiment/2899).
+* une concertation élargie auprès de nombreux acteurs, entre autre via les forums des [géocommuns](https://forum.geocommuns.fr/) et de [team open data](https://teamopendata.org/t/identifiant-unique-batiment/2899).
 * l'animation du [groupe de travail bati](http://cnig.gouv.fr/gt-bati-a25939.html) sous l'égide du Conseil National de l'information géolocalisée [CNIG](http://cnig.gouv.fr/) qui vise à faire remonter toutes ces réflexions au niveau institutionnel et à aboutir à un standard commun.
 
 A l'issue de ces initiatives phases, une première définition du bâtiment a été enterrinée lors de la commission des standards du CNIG de Novembre 2022. Vous retrouverez [ici](https://github.com/fab-geocommuns/BatID/tree/main/CNIG) les éléments relatifs à la définition et son annexe.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Afin d'aboutir à une définition du bâtiment satisfaisante, il est nécessaire
 Diverses initiatives ont été menées par l'équipe Bat-ID :
 
 * des ateliers de co-création de définitions auprès de plusieurs organisations productrices de données, dont les résultats sont disponibles [ici](docs/Synthèse-Ateliers-de-Définition-Bat-ID.pdf).
-* une concertation élargie auprès de nombreux acteurs, entre autre via les forums des [géocommuns](https://forum.geocommuns.fr/) et de [team open data](https://teamopendata.org/t/identifiant-unique-batiment/2899).
+* une concertation élargie auprès de nombreux acteurs, entre autre via les forums des [géocommuns]() et de [team open data](https://teamopendata.org/t/identifiant-unique-batiment/2899).
 * l'animation du [groupe de travail bati](http://cnig.gouv.fr/gt-bati-a25939.html) sous l'égide du Conseil National de l'information géolocalisée [CNIG](http://cnig.gouv.fr/) qui vise à faire remonter toutes ces réflexions au niveau institutionnel et à aboutir à un standard commun.
 
 A l'issue de ces initiatives phases, une première définition du bâtiment a été enterrinée lors de la commission des standards du CNIG de Novembre 2022. Vous retrouverez [ici](https://github.com/fab-geocommuns/BatID/tree/main/CNIG) les éléments relatifs à la définition et son annexe.


### PR DESCRIPTION
This PR brings correction to github action performing markdown lint

it introduces the following modifications : 
- fixes md lint rules json
- added missing checkout in actions
- Removed trigger on this specific branch only here for testing and it is working now
